### PR TITLE
PsiOps latency changes.

### DIFF
--- a/maps/torch/job/hestia_jobs.dm
+++ b/maps/torch/job/hestia_jobs.dm
@@ -211,7 +211,7 @@
 		"Foundation Agent")
 
 /datum/job/psiadvisor/equip(var/mob/living/carbon/human/H)
-	psi_faculties = list("[PSI_REDACTION]" = PSI_RANK_OPERANT, "[PSI_COERCION]" = PSI_RANK_OPERANT, "[PSI_PSYCHOKINESIS]" = PSI_RANK_OPERANT, "[PSI_ENERGISTICS]" = PSI_RANK_OPERANT)
+	psi_faculties = list("[PSI_REDACTION]" = PSI_RANK_LATENT, "[PSI_COERCION]" = PSI_RANK_LATENT, "[PSI_PSYCHOKINESIS]" = PSI_RANK_LATENT, "[PSI_ENERGISTICS]" = PSI_RANK_LATENT)
 	return ..()
 
 /datum/job/psiadvisor/get_description_blurb()


### PR DESCRIPTION
This prevents people from instantly knowing haha psiops only has operant, and rushing their jerriman and standing next to an intercom to wait for the event.

Also having people be the same consistent strength is pretty yikes, and makes it get old after a while when everyone else rolls grandmaster/paramount for less.


🆑 Yawet330
tweak: Psionic Advisors now spawn with latent instead of operant.
/🆑