### PR TITLE
GAS Job Unrestriction

### DIFF
--- a/code/modules/culture_descriptor/culture/cultures_serpentid.dm
+++ b/code/modules/culture_descriptor/culture/cultures_serpentid.dm
@@ -49,7 +49,7 @@
 
 /decl/cultural_info/culture/nabber/b
 	name = CULTURE_NABBER_B
-	valid_jobs = list(/datum/job/bartender, /datum/job/chef)
+	valid_jobs = list(/datum/job/bartender, /datum/job/cargo_tech, /datum/job/chef, /datum/job/mining, /datum/job/medical_trainee, /datum/job/engineer_trainee, /datum/job/explorer)
 
 /decl/cultural_info/culture/nabber/b/minus
 	name = CULTURE_NABBER_BMINUS
@@ -59,7 +59,7 @@
 
 /decl/cultural_info/culture/nabber/a
 	name = CULTURE_NABBER_A
-	valid_jobs = list(/datum/job/chemist, /datum/job/roboticist)
+	valid_jobs = list(/datum/job/chemist, /datum/job/roboticist, /datum/job/psiadvisor, /datum/job/explorer, /datum/job/engineer, /datum/job/engineer_trainee, /datum/job/doctor, /datum/job/medical_trainee, /datum/job/mining, /datum/job/scientist, /datum/job/scientist_assistant, /datum/job/merchant)//SKYRAT EDIT, GAS smart.
 
 /decl/cultural_info/culture/nabber/a/minus
 	name = CULTURE_NABBER_AMINUS

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -1,7 +1,6 @@
 /datum/map/torch
 	species_to_job_whitelist = list(
-		/datum/species/nabber = list(/datum/job/ai, /datum/job/cyborg, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/chemist,
-									 /datum/job/roboticist, /datum/job/cargo_tech, /datum/job/chef, /datum/job/engineer, /datum/job/doctor, /datum/job/bartender),
+		/datum/species/nabber = list(/datum/job/psiadvisor,/datum/job/explorer,/datum/job/engineer, /datum/job/roboticist, /datum/job/engineer_trainee,/datum/job/doctor, /datum/job/chemist, /datum/job/medical_trainee,/datum/job/psychiatrist, /datum/job/chaplain,/datum/job/cargo_tech, /datum/job/mining,/datum/job/janitor, /datum/job/chef, /datum/job/bartender,/datum/job/scientist, /datum/job/scientist_assistant,/datum/job/ai, /datum/job/cyborg,/datum/job/merchant), //SKYRAT EDIT.
 		/datum/species/vox/ = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant),
 		/datum/species/vox/armalis = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant),
 		/datum/species/human/mule = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant)


### PR DESCRIPTION
GAS currently have far too little jobs enabled for them to justify playing them lowpop, for balance sake, any sec job is disabled. For RP sake, GAS are essentially toddlers mentally - so no senior/command roles (Past the PADV because GAS can become latent ingame, and it doesnt actually _have_ responsibility)

🆑 Yawet330
tweak: GAS now have a multitude of jobs available to them
/🆑